### PR TITLE
Updated esx code

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -41,10 +41,9 @@ Player = {
 local societymoney, societymoney2 = nil, nil
 
 Citizen.CreateThread(function()
-	while ESX == nil do
-		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-		Citizen.Wait(10)
-	end
+	ESX = nil
+
+	ESX = exports['es_extended']:getSharedObject()
 
 	while ESX.GetPlayerData().job == nil do
 		Citizen.Wait(10)


### PR DESCRIPTION
I updated the esx export code. This is important because is it not the newtest export its drop an error:

OLD:
while ESX == nil do
		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
		Citizen.Wait(10)
	end

NEW:
ESX = nil

ESX = exports['es_extended']:getSharedObject()