### PR TITLE
refactor: support for "GPS" translations natively through the locales folder

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -13,7 +13,7 @@ local Keys = {
 Config = {}
 
 -- LANGUAGE --
-Config.Locale = 'fr'
+Config.Locale = 'en'
 
 -- GENERAL --
 Config.MenuTitle = 'ServerName' -- change it to you're server name
@@ -33,16 +33,16 @@ Config.Controls = {
 
 -- GPS --
 Config.GPS = {
-	{label = 'Aucun', coords = nil},
-	{label = 'Poste de Police', coords = vector2(425.13, -979.55)},
-	{label = 'Garage Central', coords = vector2(-449.67, -340.83)},
-	{label = 'Hôpital', coords = vector2(-33.88, -1102.37)},
-	{label = 'Concessionnaire', coords = vector2(215.06, -791.56)},
-	{label = 'Benny\'s Custom', coords = vector2(-212.13, -1325.27)},
-	{label = 'Pôle Emploie', coords = vector2(-264.83, -964.54)},
-	{label = 'Auto école', coords = vector2(-829.22, -696.99)},
-	{label = 'Téquila-la', coords = vector2(-565.09, 273.45)},
-	{label = 'Bahama Mamas', coords = vector2(-1391.06, -590.34)}
+	{label = _U('none'), coords = nil},
+	{label = _U('police_station'), coords = vector2(425.13, -979.55)},
+	{label = _U('central_garage'), coords = vector2(-449.67, -340.83)},
+	{label = _U('hospital'), coords = vector2(-33.88, -1102.37)},
+	{label = _U('dealer'), coords = vector2(215.06, -791.56)},
+	{label = _U('bennys_custom'), coords = vector2(-212.13, -1325.27)},
+	{label = _U('job_center'), coords = vector2(-264.83, -964.54)},
+	{label = _U('driving_school'), coords = vector2(-829.22, -696.99)},
+	{label = _U('tequila-la'), coords = vector2(-565.09, 273.45)},
+	{label = _U('bahama_mamas'), coords = vector2(-1391.06, -590.34)}
 }
 
 -- VOICE --
@@ -220,7 +220,7 @@ Config.Admin = {
 
 			if plyId ~= nil then
 				plyId = tonumber(plyId)
-				
+
 				if type(plyId) == 'number' then
 					TriggerServerEvent('krz_personalmenu:Admin_BringS', GetPlayerServerId(PlayerId()), plyId)
 				end
@@ -238,7 +238,7 @@ Config.Admin = {
 
 			if plyId ~= nil then
 				plyId = tonumber(plyId)
-				
+
 				if type(plyId) == 'number' then
 					TriggerServerEvent('krz_personalmenu:Admin_BringS', plyId, GetPlayerServerId(PlayerId()))
 				end
@@ -256,7 +256,7 @@ Config.Admin = {
 
 			if pos ~= nil and pos ~= '' then
 				local _, _, x, y, z = string.find(pos, '([%d%.]+) ([%d%.]+) ([%d%.]+)')
-						
+
 				if x ~= nil and y ~= nil and z ~= nil then
 					SetEntityCoords(plyPed, x + .0, y + .0, z + .0)
 				end
@@ -489,7 +489,7 @@ Config.Admin = {
 
 			if plyId ~= nil then
 				plyId = tonumber(plyId)
-				
+
 				if type(plyId) == 'number' then
 					TriggerServerEvent('esx_ambulancejob:revive', plyId)
 				end

--- a/locales/br.lua
+++ b/locales/br.lua
@@ -23,12 +23,10 @@ Locales['br'] = {
 	['gave_ammo'] = 'Você deu x%s munições para %s',
 	['no_ammo'] = 'Você não tem munição',
 	['not_enough_ammo'] = 'Você não tem tantas munições',
-
 	['accessories_no_ears'] = 'Vous ne possédez pas d\'Accessoire d\'Oreilles',
 	['accessories_no_glasses'] = 'Você não tem um óculos',
 	['accessories_no_helmet'] = 'Você não tem um capacete / chapéu',
 	['accessories_no_mask'] = 'Você não tem uma máscara',
-
 	['admin_noclipon'] = 'NoClip ~g~ativado',
 	['admin_noclipoff'] = 'NoClip ~r~desativado',
 	['admin_godmodeon'] = 'Godmod ~g~ativado',
@@ -114,14 +112,12 @@ Locales['br'] = {
 	['animation_party_rock'] = 'Rock\'n\'roll',
 	['animation_party_drunk'] = 'Bourré sur place',
 	['animation_party_vomit'] = 'Vômito de carro ',
-
 	['animation_salute_title'] = 'Saudações',
 	['animation_salute_saluate'] = 'Cumprimentar',
 	['animation_salute_serrer'] = 'Apertar as mãos',
 	['animation_salute_tchek'] = 'Eae mano!',
 	['animation_salute_bandit'] = 'Cumprimentar de Bandido',
 	['animation_salute_military'] = 'Cumprimentar de Militar',
-
 	['animation_work_title'] = 'Trabalhar',
 	['animation_work_suspect'] = 'Se render',
 	['animation_work_fisherman'] = 'Pescador',
@@ -141,7 +137,6 @@ Locales['br'] = {
 	['animation_work_hammer'] = 'Variados : Martelar paredes',
 	['animation_work_beg'] = 'SDF : Esmola',
 	['animation_work_statue'] = 'SDF : Estátua',
-
 	['animation_mood_title'] = 'Humor',
 	['animation_mood_felicitate'] = 'Palmas',
 	['animation_mood_nice'] = 'Joinha',
@@ -162,14 +157,12 @@ Locales['br'] = {
 	['animation_mood_fuckyou'] = 'Foda-se',
 	['animation_mood_wanker'] = 'Punheta',
 	['animation_mood_suicide'] = 'Suicídio',
-
 	['animation_sports_title'] = 'Esportes',
 	['animation_sports_muscle'] = 'Mostrar músculos',
 	['animation_sports_weightbar'] = 'Levantar barra de musculação',
 	['animation_sports_pushup'] = 'Faire des pompes',
 	['animation_sports_abs'] = 'Faire des abdos',
 	['animation_sports_yoga'] = 'Faire du yoga',
-
 	['animation_other_title'] = 'Variados',
 	['animation_other_sit'] = 'Sauce',
 	['animation_other_waitwall'] = 'Encostado fumando um cigarro',
@@ -180,7 +173,6 @@ Locales['br'] = {
 	['animation_other_search'] = 'Position de Fouille',
 	['animation_other_selfie'] = 'Tirar uma selfie',
 	['animation_other_door'] = 'Escutar uma porta',
-
 	['animation_pegi_title'] = 'PEGI 21',
 	['animation_pegi_hsuck'] = 'Boquete no carro',
 	['animation_pegi_fsuck'] = 'Femme suc** en voiture',
@@ -193,7 +185,6 @@ Locales['br'] = {
 	['animation_pegi_strip1'] = 'Strip Tease 1',
 	['animation_pegi_strip2'] = 'Strip Tease 2',
 	['animation_pegi_stripfloor'] = 'Strip Tease au sol',
-
 	['animation_attitudes_title'] = 'Estilo de andar',
 
 	-- Vehicle Menu
@@ -242,5 +233,17 @@ Locales['br'] = {
 	['admin_tpmarker_button'] = 'Teleporte para a localização marcada',
 	['admin_revive_button'] = 'Reviver jogador',
 	['admin_changeskin_button'] = 'Mudar aparência',
-	['admin_saveskin_button'] = 'Salvar aparência'
+	['admin_saveskin_button'] = 'Salvar aparência',
+
+	-- GPS
+	['none'] = 'No Location', -- No translated
+	['police_station'] = 'Police Station', -- No translated
+	['central_garage'] = 'Central garage', -- No translated
+	['hospital'] = 'Hospital', -- No translated
+	['dealer'] = 'Cardealer', -- No translated
+	['bennys_custom'] = 'Bennys Custom', -- No translated
+	['job_center'] = 'Employment center', -- No translated
+	['driving_school'] = 'Driving school', -- No translated
+	['tequila-la'] = 'tequila-la', -- No translated
+	['bahama_mamas'] = 'bahama_mamas' -- No translated
 }

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -23,12 +23,10 @@ Locales['de'] = {
 	['gave_ammo'] = 'Du hast x %s Munition an %s gegeben',
 	['no_ammo'] = 'Du hast keine Munition',
 	['not_enough_ammo'] = 'Du hast nicht so viel Munition',
-
 	['accessories_no_ears'] = 'Du hast kein Ohr Zubehör',
 	['accessories_no_glasses'] = 'Du hast keine Brille',
 	['accessories_no_helmet'] = 'Du hast keinen Helm/Hut',
 	['accessories_no_mask'] = 'Du hast keine Maske',
-
 	['admin_noclipon'] = 'NoClip ~g~ aktiviert',
 	['admin_noclipoff'] = 'NoClip ~r~ deaktiviert',
 	['admin_godmodeon'] = 'Invincible ~g~ aktiviert',
@@ -114,14 +112,12 @@ Locales['de'] = {
 	['animation_party_rock'] = 'Rock n roll',
 	['animation_party_drunk'] = 'Stuck on the spot',
 	['animation_party_vomit'] = 'Vomit by car',
-
 	['animation_salute_title'] = 'Greetings',
 	['animation_salute_saluate'] = 'Greet',
 	['animation_salute_serrer'] = 'Shake hands',
 	['animation_salute_tchek'] = 'Chek',
 	['animation_salute_bandit'] = 'Hi bandit',
 	['animation_salute_military'] = 'Hi Military',
-
 	['animation_work_title'] = 'Work',
 	['animation_work_suspect'] = 'surrender',
 	['animation_work_fisherman'] = 'Fisherman',
@@ -141,7 +137,6 @@ Locales['de'] = {
 	['animation_work_hammer'] = 'All: Hammer blow',
 	['animation_work_beg'] = 'SDF: Make the round',
 	['animation_work_statue'] = 'SDF: Make the statue',
-
 	['animation_mood_title'] = 'Moods',
 	['animation_mood_felicitate'] = 'Congratulate',
 	['animation_mood_nice'] = 'Super',
@@ -162,14 +157,12 @@ Locales['de'] = {
 	['animation_mood_fuckyou'] = 'Finger of Honor',
 	['animation_mood_wanker'] = 'Wanker',
 	['animation_mood_suicide'] = 'Ball in the head',
-
 	['animation_sports_title'] = 'Sports',
 	['animation_sports_muscle'] = 'Show your muscles',
 	['animation_sports_weightbar'] = 'Weight bar',
 	['animation_sports_pushup'] = 'Make pumps',
 	['animation_sports_abs'] = 'Make abs',
 	['animation_sports_yoga'] = 'Do yoga',
-
 	['animation_other_title'] = 'Miscellaneous',
 	['animation_other_sit'] = 'Sit ',
 	['animation_other_waitwall'] = 'Wait against a wall',
@@ -180,7 +173,6 @@ Locales['de'] = {
 	['animation_other_search'] = 'Search Position',
 	['animation_other_selfie'] = 'Take a selfie',
 	['animation_other_door'] = 'Listen to a door',
-
 	['animation_pegi_title'] = 'PEGI 21',
 	['animation_pegi_hsuck'] = 'Man getting sucked in the car',
 	['animation_pegi_fsuck'] = 'Woman sucks in the car',
@@ -193,7 +185,6 @@ Locales['de'] = {
 	['animation_pegi_strip1'] = 'Strip Tease 1',
 	['animation_pegi_strip2'] = 'Strip Tease 2',
 	['animation_pegi_stripfloor'] = 'Strip Tease on the ground',
-
 	['animation_attitudes_title'] = 'Approach',
 
 	-- Vehicle Menu
@@ -208,7 +199,6 @@ Locales['de'] = {
 	['vehicle_door_backright'] = 'Hinten Rechts',
 
 	-- Boss Management Menu
-
 	['bossmanagement_title'] = 'Firmen Managment',
 	['bossmanagement_chest_button'] = 'Tresor: ',
 	['bossmanagement_hire_button'] = 'Einstellen',
@@ -217,7 +207,6 @@ Locales['de'] = {
 	['bossmanagement_demote_button'] = 'Degradieren',
 
 	-- Boss Management 2 Menu
-
 	['bossmanagement2_title'] = 'Organisation Management',
 	['bossmanagement2_chest_button'] = 'Organisation Truhe:',
 	['bossmanagement2_hire_button'] = 'Einstellen',
@@ -244,5 +233,17 @@ Locales['de'] = {
 	['admin_tpmarker_button'] = 'Zur Markierung teleportieren',
 	['admin_revive_button'] = 'Spieler wiederbeleben',
 	['admin_changeskin_button'] = 'Aussehen ändern',
-	['admin_saveskin_button'] = 'Aussehen speichern'
+	['admin_saveskin_button'] = 'Aussehen speichern',
+
+	-- GPS
+	['none'] = 'No Location', -- No translated
+	['police_station'] = 'Police Station', -- No translated
+	['central_garage'] = 'Central garage', -- No translated
+	['hospital'] = 'Hospital', -- No translated
+	['dealer'] = 'Cardealer', -- No translated
+	['bennys_custom'] = 'Bennys Custom', -- No translated
+	['job_center'] = 'Employment center', -- No translated
+	['driving_school'] = 'Driving school', -- No translated
+	['tequila-la'] = 'tequila-la', -- No translated
+	['bahama_mamas'] = 'bahama_mamas' -- No translated
 }

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -23,12 +23,10 @@ Locales['en'] = {
 	['gave_ammo'] = 'You have given x %s ammo to %s',
 	['no_ammo'] = 'You do not have any ammo',
 	['not_enough_ammo'] = 'You do not have as many ammo',
-
 	['accessories_no_ears'] = 'You do not have an Ear Accessory',
 	['accessories_no_glasses'] = 'You do not have glasses',
 	['accessories_no_helmet'] = 'You do not have a Helmet / Hat',
 	['accessories_no_mask'] = 'You do not have a mask',
-
 	['admin_noclipon'] = 'NoClip ~g~ enabled',
 	['admin_noclipoff'] = 'NoClip ~r~ disabled',
 	['admin_godmodeon'] = 'Invincible ~g~ enabled',
@@ -102,7 +100,6 @@ Locales['en'] = {
 
 	-- Animation Menu
 	['animation_title'] = 'Animations',
-
 	['animation_party_title'] = 'Festivals',
 	['animation_party_smoke'] = 'Smoking a cigarette',
 	['animation_party_playsong'] = 'Play music',
@@ -114,14 +111,12 @@ Locales['en'] = {
 	['animation_party_rock'] = 'Rock n roll',
 	['animation_party_drunk'] = 'Stuck on the spot',
 	['animation_party_vomit'] = 'Vomit by car',
-
 	['animation_salute_title'] = 'Greetings',
 	['animation_salute_saluate'] = 'Greet',
 	['animation_salute_serrer'] = 'Shake hands',
 	['animation_salute_tchek'] = 'Chek',
 	['animation_salute_bandit'] = 'Hi bandit',
 	['animation_salute_military'] = 'Hi Military',
-
 	['animation_work_title'] = 'Work',
 	['animation_work_suspect'] = 'surrender',
 	['animation_work_fisherman'] = 'Fisherman',
@@ -141,7 +136,6 @@ Locales['en'] = {
 	['animation_work_hammer'] = 'All: Hammer blow',
 	['animation_work_beg'] = 'SDF: Make the round',
 	['animation_work_statue'] = 'SDF: Make the statue',
-
 	['animation_mood_title'] = 'Moods',
 	['animation_mood_felicitate'] = 'Congratulate',
 	['animation_mood_nice'] = 'Super',
@@ -162,14 +156,12 @@ Locales['en'] = {
 	['animation_mood_fuckyou'] = 'Finger of Honor',
 	['animation_mood_wanker'] = 'Wanker',
 	['animation_mood_suicide'] = 'Ball in the head',
-
 	['animation_sports_title'] = 'Sports',
 	['animation_sports_muscle'] = 'Show your muscles',
 	['animation_sports_weightbar'] = 'Weight bar',
 	['animation_sports_pushup'] = 'Make pumps',
 	['animation_sports_abs'] = 'Make abs',
 	['animation_sports_yoga'] = 'Do yoga',
-
 	['animation_other_title'] = 'Miscellaneous',
 	['animation_other_sit'] = 'Sit ',
 	['animation_other_waitwall'] = 'Wait against a wall',
@@ -180,7 +172,6 @@ Locales['en'] = {
 	['animation_other_search'] = 'Search Position',
 	['animation_other_selfie'] = 'Take a selfie',
 	['animation_other_door'] = 'Listen to a door',
-
 	['animation_pegi_title'] = 'PEGI 21',
 	['animation_pegi_hsuck'] = 'Man getting sucked in the car',
 	['animation_pegi_fsuck'] = 'Woman sucks in the car',
@@ -193,7 +184,6 @@ Locales['en'] = {
 	['animation_pegi_strip1'] = 'Strip Tease 1',
 	['animation_pegi_strip2'] = 'Strip Tease 2',
 	['animation_pegi_stripfloor'] = 'Strip Tease on the ground',
-
 	['animation_attitudes_title'] = 'Approach',
 
 	-- Vehicle Menu
@@ -208,7 +198,6 @@ Locales['en'] = {
 	['vehicle_door_backright'] = 'Rear Right',
 
 	-- Boss Management Menu
-
 	['bossmanagement_title'] = 'Company Management',
 	['bossmanagement_chest_button'] = 'Company Safe:',
 	['bossmanagement_hire_button'] = 'Recruit',
@@ -217,7 +206,6 @@ Locales['en'] = {
 	['bossmanagement_demote_button'] = 'Demote',
 
 	-- Boss Management 2 Menu
-
 	['bossmanagement2_title'] = 'Organization Management',
 	['bossmanagement2_chest_button'] = 'Organization Chest:',
 	['bossmanagement2_hire_button'] = 'Recruit',
@@ -244,5 +232,17 @@ Locales['en'] = {
 	['admin_tpmarker_button'] = 'TP on the Marker',
 	['admin_revive_button'] = 'Revive a Player',
 	['admin_changeskin_button'] = 'Change Appearance',
-	['admin_saveskin_button'] = 'Save Appearance'
+	['admin_saveskin_button'] = 'Save Appearance',
+
+	-- GPS
+	['none'] = 'No Location',
+	['police_station'] = 'Police Station',
+	['central_garage'] = 'Central garage',
+	['hospital'] = 'Hospital',
+	['dealer'] = 'Cardealer',
+	['bennys_custom'] = 'Bennys Custom',
+	['job_center'] = 'Employment center',
+	['driving_school'] = 'Driving school',
+	['tequila-la'] = 'tequila-la',
+	['bahama_mamas'] = 'bahama_mamas'
 }

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -23,12 +23,10 @@ Locales['es'] = {
 	['gave_ammo'] = 'Distes x %s munición a %s',
 	['no_ammo'] = 'No tienes munición',
 	['not_enough_ammo'] = 'No tienes suficiente munición',
-
 	['accessories_no_ears'] = 'No tienes un accesorio de oreja',
 	['accessories_no_glasses'] = 'No tienes gafas',
 	['accessories_no_helmet'] = 'No tienes casco / gorra / gorro',
 	['accessories_no_mask'] = 'No tienes una máscara',
-
 	['admin_noclipon'] = 'NoClip ~g~ habilitado',
 	['admin_noclipoff'] = 'NoClip ~r~ deshabilitado',
 	['admin_godmodeon'] = 'Invencible ~g~ habilitado',
@@ -102,7 +100,6 @@ Locales['es'] = {
 
 	-- Animation Menu
 	['animation_title'] = 'Animaciones',
-
 	['animation_party_title'] = 'Festivales',
 	['animation_party_smoke'] = 'Fumar un cigarro',
 	['animation_party_playsong'] = 'Poner música',
@@ -114,14 +111,12 @@ Locales['es'] = {
 	['animation_party_rock'] = 'Rock n roll',
 	['animation_party_drunk'] = 'Borracho',
 	['animation_party_vomit'] = 'Vomitar',
-
 	['animation_salute_title'] = 'Saludos',
 	['animation_salute_saluate'] = 'Saludar',
 	['animation_salute_serrer'] = 'Dar la mano',
 	['animation_salute_tchek'] = 'Chek',
 	['animation_salute_bandit'] = 'Saludo bandido',
 	['animation_salute_military'] = 'Saludo militar',
-
 	['animation_work_title'] = 'Trabajo',
 	['animation_work_suspect'] = 'Rendirse',
 	['animation_work_fisherman'] = 'Pescadero',
@@ -141,7 +136,6 @@ Locales['es'] = {
 	['animation_work_hammer'] = 'Todos: Golpe de martillo',
 	['animation_work_beg'] = 'SDF: hacer la ronda',
 	['animation_work_statue'] = 'SDF: hacer la estatua',
-
 	['animation_mood_title'] = 'Estado',
 	['animation_mood_felicitate'] = 'Felicitar',
 	['animation_mood_nice'] = 'Guay',
@@ -162,14 +156,12 @@ Locales['es'] = {
 	['animation_mood_fuckyou'] = 'Dedo del medio',
 	['animation_mood_wanker'] = 'Una buena paja',
 	['animation_mood_suicide'] = 'Bala en la cabeza',
-
 	['animation_sports_title'] = 'Deportes',
 	['animation_sports_muscle'] = 'Mostrar tus músculos',
 	['animation_sports_weightbar'] = 'Barra de pesas',
 	['animation_sports_pushup'] = 'Hacer flexiones',
 	['animation_sports_abs'] = 'Hacer abdominales',
 	['animation_sports_yoga'] = 'Hacer yoga',
-
 	['animation_other_title'] = 'Random',
 	['animation_other_sit'] = 'Sentarse',
 	['animation_other_waitwall'] = 'Apoyarse contra el muro',
@@ -180,7 +172,6 @@ Locales['es'] = {
 	['animation_other_search'] = 'Buscar posición',
 	['animation_other_selfie'] = 'Sacar un selfie',
 	['animation_other_door'] = 'Escuchar por la puerta',
-
 	['animation_pegi_title'] = 'PEGI 18',
 	['animation_pegi_hsuck'] = 'Hombre recibiendo felación',
 	['animation_pegi_fsuck'] = 'Mujer chupa en el coche',
@@ -193,7 +184,6 @@ Locales['es'] = {
 	['animation_pegi_strip1'] = 'Strip Tease 1',
 	['animation_pegi_strip2'] = 'Strip Tease 2',
 	['animation_pegi_stripfloor'] = 'Strip Tease en el suelo',
-
 	['animation_attitudes_title'] = 'Acercarse',
 
 	-- Vehicle Menu
@@ -208,7 +198,6 @@ Locales['es'] = {
 	['vehicle_door_backright'] = 'Puerta trasera derecha',
 
 	-- Boss Management Menu
-
 	['bossmanagement_title'] = 'Negocios',
 	['bossmanagement_chest_button'] = 'Negocio Cofre:',
 	['bossmanagement_hire_button'] = 'Reclutar',
@@ -217,7 +206,6 @@ Locales['es'] = {
 	['bossmanagement_demote_button'] = 'Degradar',
 
 	-- Boss Management 2 Menu
-
 	['bossmanagement2_title'] = 'Organización',
 	['bossmanagement2_chest_button'] = 'Organization Cofre:',
 	['bossmanagement2_hire_button'] = 'Reclutar',
@@ -244,5 +232,17 @@ Locales['es'] = {
 	['admin_tpmarker_button'] = 'TP al marcador',
 	['admin_revive_button'] = 'Revivir un jugador',
 	['admin_changeskin_button'] = 'Cambiar apariencia',
-	['admin_saveskin_button'] = 'Guardar apariencia'
+	['admin_saveskin_button'] = 'Guardar apariencia',
+
+	-- GPS
+	['none'] = 'No Location', -- No translated
+	['police_station'] = 'Police Station', -- No translated
+	['central_garage'] = 'Central garage', -- No translated
+	['hospital'] = 'Hospital', -- No translated
+	['dealer'] = 'Cardealer', -- No translated
+	['bennys_custom'] = 'Bennys Custom', -- No translated
+	['job_center'] = 'Employment center', -- No translated
+	['driving_school'] = 'Driving school', -- No translated
+	['tequila-la'] = 'tequila-la', -- No translated
+	['bahama_mamas'] = 'bahama_mamas' -- No translated
 }

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -236,14 +236,14 @@ Locales['fr'] = {
 	['admin_saveskin_button'] = 'Sauvegarder l\'Apparence',
 
 	-- GPS
-	['none'] = 'No Location', -- No translated
-	['police_station'] = 'Police Station', -- No translated
-	['central_garage'] = 'Central garage', -- No translated
-	['hospital'] = 'Hospital', -- No translated
-	['dealer'] = 'Cardealer', -- No translated
-	['bennys_custom'] = 'Bennys Custom', -- No translated
-	['job_center'] = 'Employment center', -- No translated
-	['driving_school'] = 'Driving school', -- No translated
-	['tequila-la'] = 'tequila-la', -- No translated
-	['bahama_mamas'] = 'bahama_mamas' -- No translated
+	['none'] = 'Aucun',
+	['police_station'] = 'Poste de Police',
+	['central_garage'] = 'Garage Central',
+	['hospital'] = 'Hôpital',
+	['dealer'] = 'Concessionnaire',
+	['bennys_custom'] = 'Benny\'s Custom',
+	['job_center'] = 'Pôle Emploie',
+	['driving_school'] = 'Auto école',
+	['tequila-la'] = 'Téquila-la',
+	['bahama_mamas'] = 'Bahama Mamas'
 }

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -23,12 +23,10 @@ Locales['fr'] = {
 	['gave_ammo'] = 'Vous avez donné x%s munitions à %s',
 	['no_ammo'] = 'Vous ne possédez pas de munitions',
 	['not_enough_ammo'] = 'Vous ne possédez pas autant de munitions',
-
 	['accessories_no_ears'] = 'Vous ne possédez pas d\'Accessoire d\'Oreilles',
 	['accessories_no_glasses'] = 'Vous ne possédez pas de Lunettes',
 	['accessories_no_helmet'] = 'Vous ne possédez pas de Casque/Chapeau',
 	['accessories_no_mask'] = 'Vous ne possédez pas de Masque',
-
 	['admin_noclipon'] = 'NoClip ~g~activé',
 	['admin_noclipoff'] = 'NoClip ~r~désactivé',
 	['admin_godmodeon'] = 'Mode invincible ~g~activé',
@@ -114,14 +112,12 @@ Locales['fr'] = {
 	['animation_party_rock'] = 'Rock\'n\'roll',
 	['animation_party_drunk'] = 'Bourré sur place',
 	['animation_party_vomit'] = 'Vomir en voiture',
-
 	['animation_salute_title'] = 'Salutations',
 	['animation_salute_saluate'] = 'Saluer',
 	['animation_salute_serrer'] = 'Serrer la main',
 	['animation_salute_tchek'] = 'Tchek',
 	['animation_salute_bandit'] = 'Salut bandit',
 	['animation_salute_military'] = 'Salut Militaire',
-
 	['animation_work_title'] = 'Travail',
 	['animation_work_suspect'] = 'Se rendre',
 	['animation_work_fisherman'] = 'Pêcheur',
@@ -141,7 +137,6 @@ Locales['fr'] = {
 	['animation_work_hammer'] = 'Tout : Coup de marteau',
 	['animation_work_beg'] = 'SDF : Faire la manche',
 	['animation_work_statue'] = 'SDF : Faire la statue',
-
 	['animation_mood_title'] = 'Humeurs',
 	['animation_mood_felicitate'] = 'Féliciter',
 	['animation_mood_nice'] = 'Super',
@@ -162,14 +157,12 @@ Locales['fr'] = {
 	['animation_mood_fuckyou'] = 'Doigt d\'honneur',
 	['animation_mood_wanker'] = 'Branleur',
 	['animation_mood_suicide'] = 'Balle dans la tête',
-
 	['animation_sports_title'] = 'Sports',
 	['animation_sports_muscle'] = 'Montrer ses muscles',
 	['animation_sports_weightbar'] = 'Barre de musculation',
 	['animation_sports_pushup'] = 'Faire des pompes',
 	['animation_sports_abs'] = 'Faire des abdos',
 	['animation_sports_yoga'] = 'Faire du yoga',
-
 	['animation_other_title'] = 'Divers',
 	['animation_other_sit'] = 'S\'asseoir',
 	['animation_other_waitwall'] = 'Attendre contre un mur',
@@ -180,7 +173,6 @@ Locales['fr'] = {
 	['animation_other_search'] = 'Position de Fouille',
 	['animation_other_selfie'] = 'Prendre un selfie',
 	['animation_other_door'] = 'Ecouter à une porte',
-
 	['animation_pegi_title'] = 'PEGI 21',
 	['animation_pegi_hsuck'] = 'Homme se faire suc** en voiture',
 	['animation_pegi_fsuck'] = 'Femme suc** en voiture',
@@ -193,7 +185,6 @@ Locales['fr'] = {
 	['animation_pegi_strip1'] = 'Strip Tease 1',
 	['animation_pegi_strip2'] = 'Strip Tease 2',
 	['animation_pegi_stripfloor'] = 'Strip Tease au sol',
-
 	['animation_attitudes_title'] = 'Démarche',
 
 	-- Vehicle Menu
@@ -242,5 +233,17 @@ Locales['fr'] = {
 	['admin_tpmarker_button'] = 'TP sur le Marqueur',
 	['admin_revive_button'] = 'Réanimer un Joueur',
 	['admin_changeskin_button'] = 'Changer l\'Apparence',
-	['admin_saveskin_button'] = 'Sauvegarder l\'Apparence'
+	['admin_saveskin_button'] = 'Sauvegarder l\'Apparence',
+
+	-- GPS
+	['none'] = 'No Location', -- No translated
+	['police_station'] = 'Police Station', -- No translated
+	['central_garage'] = 'Central garage', -- No translated
+	['hospital'] = 'Hospital', -- No translated
+	['dealer'] = 'Cardealer', -- No translated
+	['bennys_custom'] = 'Bennys Custom', -- No translated
+	['job_center'] = 'Employment center', -- No translated
+	['driving_school'] = 'Driving school', -- No translated
+	['tequila-la'] = 'tequila-la', -- No translated
+	['bahama_mamas'] = 'bahama_mamas' -- No translated
 }

--- a/locales/it.lua
+++ b/locales/it.lua
@@ -233,5 +233,17 @@ Locales['it'] = {
 	['admin_tpmarker_button'] = 'TP sul Marker',
 	['admin_revive_button'] = 'Rianima Player',
 	['admin_changeskin_button'] = 'Cambia aspetto',
-	['admin_saveskin_button'] = 'Salva aspetto'
+	['admin_saveskin_button'] = 'Salva aspetto',
+
+	-- GPS
+	['none'] = 'Nessuna Posizione',
+	['police_station'] = 'Stazione di polizia',
+	['central_garage'] = 'Garage Centrale',
+	['hospital'] = 'Ospedale',
+	['dealer'] = 'Concessionario',
+	['bennys_custom'] = 'Bennys Custom',
+	['job_center'] = 'Centro per l\'Impiego',
+	['driving_school'] = 'Scuola Guida',
+	['tequila-la'] = 'tequila-la',
+	['bahama_mamas'] = 'bahama_mamas'
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,4 @@
-TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+ESX = exports["es_extended"]:getSharedObject()
 
 do
 	local origRegisterServerEvent = RegisterServerEvent


### PR DESCRIPTION
This PR supports the "GPS" translations present in config.lua natively through the "locales" folder

- Set the English language in the config.lua file as default

- Some files have been marked with the comment "no translated" because I don't know the languages ​​in question, I hope the community can translate them 

- Fixed the obsolete export method reported in the request #120 